### PR TITLE
Feature/406 rights retention update

### DIFF
--- a/server/service/jct/api.coffee
+++ b/server/service/jct/api.coffee
@@ -457,7 +457,8 @@ API.service.jct.ta = (issn, ror) ->
 
 # import transformative agreements data from sheets 
 # https://github.com/antleaf/jct-project/blob/master/ta/public_data.md
-# only validated agreements will be exposed at the sheet
+# only validated agreements will be exposed at the following sheet
+# https://docs.google.com/spreadsheets/d/e/2PACX-1vStezELi7qnKcyE8OiO2OYx2kqQDOnNsDX1JfAsK487n2uB_Dve5iDTwhUFfJ7eFPDhEjkfhXhqVTGw/pub?gid=1130349201&single=true&output=csv
 # get the "Data URL" - if it's a valid URL, and the End Date is after current date, get the csv from it
 API.service.jct.ta.import = (mail=true) ->
   bads = []
@@ -466,8 +467,7 @@ API.service.jct.ta.import = (mail=true) ->
   console.log 'Starting ta import'
   batch = []
   bissns = [] # track ones going into the batch
-  ta_url = API.settings.data_url?.csv?.ta
-  for ov in API.service.jct.csv2json ta_url
+  for ov in API.service.jct.csv2json 'https://docs.google.com/spreadsheets/d/e/2PACX-1vStezELi7qnKcyE8OiO2OYx2kqQDOnNsDX1JfAsK487n2uB_Dve5iDTwhUFfJ7eFPDhEjkfhXhqVTGw/pub?gid=1130349201&single=true&output=csv'
     res.sheets += 1
     if typeof ov?['Data URL'] is 'string' and ov['Data URL'].trim().indexOf('http') is 0 and ov?['End Date']? and moment(ov['End Date'].trim(), 'YYYY-MM-DD').valueOf() > Date.now()
       res.ready += 1
@@ -568,8 +568,7 @@ API.service.jct.ta.import = (mail=true) ->
 API.service.jct.tj = (issn, refresh) ->
   if refresh
     console.log 'Starting tj import'
-    tj_url = API.settings.data_url?.csv?.tj
-    recs = API.service.jct.csv2json tj_url
+    recs = API.service.jct.csv2json 'https://docs.google.com/spreadsheets/d/e/2PACX-1vT2SPOjVU4CKhP7FHOgaf0aRsjSOt-ApwLOy44swojTDFsWlZAIZViC0gdbmxJaEWxdJSnUmNoAnoo9/pub?gid=0&single=true&output=csv'
     console.log 'Retrieved ' + recs.length + ' tj records from sheet'
     for rec in recs
       tj = {}
@@ -615,6 +614,8 @@ API.service.jct.tj = (issn, refresh) ->
     return jct_journal.count 'tj:true'
 
 
+# what are these qualifications relevant to? TAs?
+# there is no funder qualification done now, due to retention policy change decision at ened of October 2020. May be added again later.
 # rights_retention_author_advice - 
 # rights_retention_funder_implementation - the journal does not have an SA policy and the funder has a rights retention policy that starts in the future. 
 # There should be one record of this per funder that meets the conditions, and the following qualification specific data is requried:
@@ -624,34 +625,33 @@ API.service.jct.tj = (issn, refresh) ->
 API.service.jct.retention = (issn, refresh) ->
   # check the rights retention data source once it exists if the record is not in OAB
   # for now this is a fallback to something that is not in OAB
-  # will be a list of journals by ISSN
-  # If they exists, then it has a rights retention exception
+  # will be a list of journals by ISSN and a number 1,2,3,4,5
   if refresh
     counter = 0
-    csv_data = API.settings.data_url?.csv?.sa_prohibited
-    for rt in API.service.jct.csv2json csv_data
+    for rt in API.service.jct.csv2json 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTVZwZtdYSUFfKVRGO3jumQcLEjtnbdbw7yJ4LvfC2noYn3IwuTDjA9CEjzSaZjX8QVkWijqa3rmicY/pub?gid=0&single=true&output=csv'
       counter += 1
       console.log('Retention import ' + counter) if counter % 20 is 0
-      rt.journal = rt['Journal Title'].trim() if typeof rt['Journal Title'] is 'string'
+      rt.journal = rt['Journal Name'].trim() if typeof rt['Journal Name'] is 'string'
       rt.issn = []
       rt.issn.push(rt['ISSN (print)'].trim().toUpperCase()) if typeof rt['ISSN (print)'] is 'string' and rt['ISSN (print)'].length
-      rt.issn.push(rt['ISSN (electronic)'].trim().toUpperCase()) if typeof rt['ISSN (electronic)'] is 'string' and rt['ISSN (electronic)'].length
+      rt.issn.push(rt['ISSN (online)'].trim().toUpperCase()) if typeof rt['ISSN (online)'] is 'string' and rt['ISSN (online)'].length
+      rt.position = if typeof rt.Position is 'number' then rt.Position else parseInt rt.Position.trim()
       rt.publisher = rt.Publisher.trim() if typeof rt.Publisher is 'string'
-      if rt.issn.length
+      if rt.issn.length and rt.position? and typeof rt.position is 'number' and rt.position isnt null and not isNaN rt.position
         if exists = jct_journal.find 'issn.exact:"' + rt.issn.join('" OR issn.exact:"') + '"'
           upd = {}
-          for isn in rt.issn
+          for isn in rec.issn
             if isn not in exists.issn
               upd.issn ?= []
               upd.issn.push isn
-          upd.retained = false if exists.retained isnt false
+          upd.retained = true if exists.retained isnt true
           upd.retention = rt if not exists.retention?
           if JSON.stringify(upd) isnt '{}'
             for en in exists.issn
               upd.issn.push(en) if typeof en is 'string' and en.length and en not in upd.issn
             jct_journal.update exists._id, upd
         else
-          rec = retained: false, retention: rt, issn: rt.issn, publisher: rt.publisher, title: rt.journal
+          rec = retained: true, retention: rt, issn: rt.issn, publisher: rt.publisher, title: rt.journal
           jct_journal.insert rec
 
   if issn
@@ -663,19 +663,23 @@ API.service.jct.retention = (issn, refresh) ->
       issn: issn
       log: []
 
-    if exists = jct_journal.find 'retained:false AND (issn.exact:"' + issn.join('" OR issn.exact:"') + '")'
-      delete res.qualifications
-      res.log.push code: 'SA.RRException'
-      res.log.push code: 'SA.NonCompliant'
-      res.compliant = 'no'
-      # new log code also states there should be an SA.Unknown, but given we default to
-      # Non compliant at the moment, I don't see a way to achieve that, so set as Non Compliant for now
+    if exists = jct_journal.find 'retained:true AND (issn.exact:"' + issn.join('" OR issn.exact:"') + '")'
+      if exists.position is 5 # if present and 5, not compliant
+        delete res.qualifications
+        res.log.push code: 'SA.NonCompliant'
+        res.compliant = 'no'
+      else
+        res.log.push code: 'SA.Compliant'
+        # https://github.com/antleaf/jct-project/issues/215#issuecomment-726761965
+        # if present and any other number, or no answer, then compliant with some funder quals - so what funder quals to add?
+        # no funder quals now due to change at end of October 2020. May be introduced again later
     else
-      res.log.push code: 'SA.RRNoException'
-      res.log.push code: 'SA.Compliant'
+      # new log code algo states there should be an SA.Unknown, but given we default to 
+      # compliant at the moment, I don't see a way to achieve that, so set as Compliant for now
+      res.log.push(code: 'SA.Compliant') if res.log.length is 0
     return res
   else
-    return jct_journal.count 'retained:false'
+    return jct_journal.count 'retained:true'
 
 
 API.service.jct.permission = (issn, institution) ->

--- a/server/service/jct/api.coffee
+++ b/server/service/jct/api.coffee
@@ -682,7 +682,7 @@ API.service.jct.retention = (issn, refresh) ->
       rt.issn.push(rt['ISSN (online)'].trim().toUpperCase()) if typeof rt['ISSN (online)'] is 'string' and rt['ISSN (online)'].length
       rt.position = if typeof rt.Position is 'number' then rt.Position else parseInt rt.Position.trim()
       rt.publisher = rt.Publisher.trim() if typeof rt.Publisher is 'string'
-      if rt.issn.length and rt.position? and typeof rt.position is 'number' and rt.position isnt null and not isNaN rt.position
+      if rt.issn.length
         if exists = jct_journal.find 'issn.exact:"' + rt.issn.join('" OR issn.exact:"') + '"'
           upd = {}
           upd.issn ?= []
@@ -710,16 +710,9 @@ API.service.jct.retention = (issn, refresh) ->
       log: []
 
     if exists = jct_journal.find 'retained:true AND (issn.exact:"' + issn.join('" OR issn.exact:"') + '")'
-      # https://github.com/antleaf/jct-project/issues/406 no qualification needed if retained is true
+      # https://github.com/antleaf/jct-project/issues/406 no qualification needed if retained is true. Position not used.
       delete res.qualifications
-      if exists.position is 5 # if present and 5, not compliant
-        res.log.push code: 'SA.NonCompliant'
-        res.compliant = 'no'
-      else
-        res.log.push code: 'SA.Compliant'
-        # https://github.com/antleaf/jct-project/issues/215#issuecomment-726761965
-        # if present and any other number, or no answer, then compliant with some funder quals - so what funder quals to add?
-        # no funder quals now due to change at end of October 2020. May be introduced again later
+      res.log.push code: 'SA.Compliant'
     else
       # new log code algo states there should be an SA.Unknown, but given we default to 
       # compliant at the moment, I don't see a way to achieve that, so set as Compliant for now

--- a/server/service/jct/api.coffee
+++ b/server/service/jct/api.coffee
@@ -780,7 +780,7 @@ API.service.jct.permission = (issn, institution) ->
 
 
 # Calculate self archiving check. It combines, sa_prohibited, OA.works permission and rr checks
-API.service.jct.sa = (journal, institution, funder, retention, sa_prohibition) ->
+API.service.jct.sa = (journal, institution, funder, retention=true, sa_prohibition=true) ->
   # Get SA prohibition
   if journal and sa_prohibition
     res_sa = API.service.jct.sa_prohibited journal, undefined

--- a/template.settings.json
+++ b/template.settings.json
@@ -1,0 +1,27 @@
+{
+  "name": "noddy",
+  "version": "3.1.0",
+  "dev": true,
+  "log": {
+    "level": "debug"
+  },
+  "es": {
+    "url": "http://localhost:9200",
+    "index": "noddy"
+  },
+  "service": {
+    "jct": {
+      "doaj": {
+        "apikey": "<add doaj api key here>"
+      }
+    }
+  },
+  "data_url": {
+    "csv" : {
+      "ta": "add gsheets link to ta spreadsheet published as csv",
+      "tj": "add gsheets link to tj spreadsheet published as csv",
+      "sa_rr": "add gsheets link to rights retention spreadsheet published as csv",
+      "sa_prohibited": "add gsheets link to self archiving - rights retention prohibited spreadsheet published as csv"
+    }
+  }
+}


### PR DESCRIPTION
This is a PR for https://github.com/antleaf/jct-project/issues/406 and https://github.com/antleaf/jct-project/issues/437

This implements the logic in https://docs.google.com/document/d/1IcyPOl11TGzYg0lcajnL6Tl2ITeppL8qI6xXBhiUfIU/edit#

### Questions / clarifications from the implementation

1.  What should the routes be for self-archiving checks?
    **RR negative - I Have gone with ‘self_archiving’**
    OA,works permission - self_archiving
    RR positive spreadsheet - retention

2. The date logic for funder RR needs to be updated, as 2021-01-01 is now in the past (figure 4)
    Logic implemented in code - 
    if policy start date exists and policy start date is in past - Active

3. Does position in RR spreadsheet still have meaning in the journal RR spreadsheet? 
    I have retained the old logic and made no changes there

### Changes to the API outcome
Checks in api now returns `sa, doaj, ta and tj`. 
`permission` has been replaced by `sa`
```
"checks": [
            "sa",
            "doaj",
            "ta",
            "tj"
        ]
```

For sa, the new log codes are `SA.RRException` and `SA.RRNoException` from sa prohibited check
